### PR TITLE
Fix narrowing conversion error

### DIFF
--- a/src/DigiKeyboard.h
+++ b/src/DigiKeyboard.h
@@ -73,7 +73,7 @@ static uchar    idleRate;           // in 4 ms units
  * Redundant entries (such as LOGICAL_MINIMUM and USAGE_PAGE) have been omitted
  * for the second INPUT item.
  */
-const PROGMEM char usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH] = { /* USB report descriptor */
+const PROGMEM unsigned char usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH] = { /* USB report descriptor */
   0x05, 0x01,                    // USAGE_PAGE (Generic Desktop) 
   0x09, 0x06,                    // USAGE (Keyboard) 
   0xa1, 0x01,                    // COLLECTION (Application) 

--- a/src/usbdrv.h
+++ b/src/usbdrv.h
@@ -516,7 +516,7 @@ extern
 #if !(USB_CFG_DESCR_PROPS_HID_REPORT & USB_PROP_IS_RAM)
 const PROGMEM
 #endif
-char usbDescriptorHidReport[];
+unsigned char usbDescriptorHidReport[];
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
Newer compiler versions give a narrowing conversion error.

Fixes following errors caused in `usbHidReportDescriptor`
```cpp
DigisparkKeyboard/src/DigiKeyboard.h:95:1: error: narrowing conversion of '192' from 'int' to 'char' inside { } [-Wnarrowing]
```
